### PR TITLE
Patch 1.0.6

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: SpiecEasi
 Title: Sparse Inverse Covariance for Ecological Statistical Inference
-Version: 1.0.5
+Version: 1.0.6
 Authors@R: c(
     person("Zachary", "Kurtz", role = c("aut", "cre"), email="zdkurtz@gmail.com"),
     person("Christian", "Mueller", role = "aut"),

--- a/R/SparseICov.R
+++ b/R/SparseICov.R
@@ -60,8 +60,7 @@ sparseiCov <- function(data, method, npn=FALSE, verbose=FALSE, cov.output = TRUE
                                             cov.output = cov.output)))
 
   } else if (method %in% c('mb')) {
-    est <- do.call(huge::huge, c(args, list(x=data,
-                                            method=method,
+    est <- do.call(huge:::huge.mb, c(args, list(x=data,
                                             verbose=verbose)))
     est$method <- 'mb'
     est$data <- data

--- a/R/SparseICov.R
+++ b/R/SparseICov.R
@@ -60,8 +60,8 @@ sparseiCov <- function(data, method, npn=FALSE, verbose=FALSE, cov.output = TRUE
                                             cov.output = cov.output)))
 
   } else if (method %in% c('mb')) {
-    est <- do.call(huge:::huge.mb, c(args, list(x=data,
-                                            verbose=verbose)))
+    est <- do.call(utils::getFromNamespace('huge.mb', 'huge'),
+                   c(args, list(x=data, verbose=verbose)))
     est$method <- 'mb'
     est$data <- data
     est$sym  <- ifelse(!is.null(args$sym), args$sym, 'or')

--- a/R/spiec-easi.R
+++ b/R/spiec-easi.R
@@ -296,6 +296,5 @@ spiec.easi.list <- function(data, ...) {
 
   if (!list.equal(snames) || !list.equal(ssizes))
     stop("Do not run multi.spiec.easi with unidentical sample scheme")
-
-  spiec.easi.default(data, ...)
+  spiec.easi.default(do.call('cbind', data), ...)
 }

--- a/R/spiec-easi.R
+++ b/R/spiec-easi.R
@@ -22,6 +22,10 @@ spiec.easi <- function(data, ...) {
 #' @keywords internal
 .data.checks <- function(data) {
   ## data checks ##
+  if (inherits(data, 'list')) {
+    sink <- lapply(data, .data.checks)
+    return(NULL)
+  }
   if (isTRUE(all.equal(rowSums(data), rep(1L, nrow(data))))) {
     warning('Data is normalized, but raw counts are expected')
   }
@@ -29,6 +33,7 @@ spiec.easi <- function(data, ...) {
   if (any(data<0)) {
     warning('Negative values detected, but raw counts are expected')
   }
+  return(NULL)
 }
 
 #' @method spiec.easi phyloseq
@@ -296,5 +301,5 @@ spiec.easi.list <- function(data, ...) {
 
   if (!list.equal(snames) || !list.equal(ssizes))
     stop("Do not run multi.spiec.easi with unidentical sample scheme")
-  spiec.easi.default(do.call('cbind', data), ...)
+  spiec.easi.default(data, ...)
 }

--- a/tests/testthat/test_multidomain.R
+++ b/tests/testthat/test_multidomain.R
@@ -1,0 +1,19 @@
+context('test multidomain spiec.easi')
+
+
+p <- 10
+e <- p
+n <- 100
+set.seed(10010)
+g <- make_graph('erdos_renyi', p, e)
+S <- cov2cor(prec2cov(graph2prec(g)))
+X <- exp(rmvnorm(n, rep(0,p), S))
+
+
+test_that("execution succeeds", {
+  expect_s3_class(
+    suppressWarnings(
+      spiec.easi(list(X[,1:5], X[,6:10]), method='mb', nlambda=4,
+        verbose=FALSE, lambda.min.ratio=1e-1, pulsar.select=FALSE)),
+    "pulsar.refit")
+})

--- a/tests/testthat/test_pulsar.R
+++ b/tests/testthat/test_pulsar.R
@@ -90,14 +90,3 @@ test_that("Getter API, batch pulsar / stars ", {
 test_that("Getter API, batch pulsar / bstars ", {
   runtests(bout.bstars)
 })
-
-
-context('test multidomain spiec.easi')
-
-test_that("execution succeeds", {
-  expect_s3_class(
-    suppressWarnings(
-      spiec.easi(list(X[,1:5], X[,6:10]), method='mb', nlambda=4,
-        verbose=FALSE, lambda.min.ratio=1e-1, pulsar.select=FALSE)),
-    "pulsar.refit")
-})

--- a/tests/testthat/test_pulsar.R
+++ b/tests/testthat/test_pulsar.R
@@ -90,3 +90,14 @@ test_that("Getter API, batch pulsar / stars ", {
 test_that("Getter API, batch pulsar / bstars ", {
   runtests(bout.bstars)
 })
+
+
+context('test multidomain spiec.easi')
+
+test_that("execution succeeds", {
+  expect_s3_class(
+    suppressWarnings(
+      spiec.easi(list(X[,1:5], X[,6:10]), method='mb', nlambda=4,
+        verbose=FALSE, lambda.min.ratio=1e-1, pulsar.select=FALSE)),
+    "pulsar.refit")
+})


### PR DESCRIPTION
Addresses issues #68, #72 & #75 

1. Revert to `huge.mb`. We'd rather use the wrapper `huge::huge` but MB betas are not returned. `huge.mb` is not exported, so use `utils::getNamespace` to avoid the `:::` warning. Not the best solution, but only option for now.
2. Previous patch added data checks, but I missed the case where  the data is a list of otu tables.  `multi.spiec.easi`/`spiec.easi.list` failing data checks.
3. Adds unit test to avoid the above in the future.