### PR TITLE
Vgam zinb synthetic data fix

### DIFF
--- a/R/mvdistributions.R
+++ b/R/mvdistributions.R
@@ -175,7 +175,7 @@ rmvzinegbin <- function(n, mu, Sigma, munbs, ks, ps, ...) {
     d   <- length(munbs)
     normd  <- rmvnorm(n, rep(0, d), Sigma=Cor)
     unif   <- pnorm(normd)
-    data <- matrix(VGAM::qzinegbin(unif, munb=munbs, size=ks, pstr0=ps, ...), n, d)
+    data <- matrix(VGAM::qzinegbin(t(unif), munb=munbs, size=ks, pstr0=ps, ...), n, d, byrow=TRUE)
     data <- .fixInf(data)
     return(data)
 }

--- a/tests/testthat/test_synth.R
+++ b/tests/testthat/test_synth.R
@@ -66,12 +66,13 @@ test_that("VGAM::qzinegbin is applied correctly to normal samples", {
     normal_samps <- rmvnorm(n=n, mu=rep(0, ncol(amgut1.filt.cs)), Sigma=cors)
     unif_probs <- pnorm(normal_samps)
 
-    seRes <- matrix(VGAM::qzinegbin(unif_probs, size=paramat$size, 
-				    munb=paramat$munb, pstr0=paramat$pstr0), n, ncol(amgut1.filt.cs))
+    seRes <- matrix(VGAM::qzinegbin(t(unif_probs), size=paramat$size, 
+				    munb=paramat$munb, pstr0=paramat$pstr0), 
+		    n, ncol(amgut1.filt.cs), byrow=TRUE)
 
     col3res <- VGAM::qzinegbin(unif_probs[,3], size=paramat$size[3], 
 			       munb=paramat$munb[3], pstr0=paramat$pstr0[3])
 
-    show(seRes[,3] == col3res)
+    # show(seRes[,3] == col3res)
     expect( all(seRes[,3] == col3res), "After application of the quantile function, did we get the correct counts back?")
 })


### PR DESCRIPTION
Tests mimic the functionality of synth_comm_from_counts and rmvzingbin.

While not directly testing the code, adding the option to pass the normal samples to synth_comm_from_counts and through to the related functions would allow for direct testing.

The implemented fix is equivalent to the fix on the `pr` branch.